### PR TITLE
V1.2

### DIFF
--- a/src/Eloquent/Model/Meta/Meta.php
+++ b/src/Eloquent/Model/Meta/Meta.php
@@ -37,11 +37,13 @@ abstract class Meta extends Model
     public function getValueAttribute()
     {
         try {
-            $value = unserialize($this->meta_value);
+            $value = @unserialize($this->meta_value); # prevent notice sent when not serialized string
 
-            return $value === false && $this->meta_value !== false ?
-                $this->meta_value :
-                $value;
+            return $value === false && $this->meta_value !== false && $this->meta_value !== 'b:0;'
+                ? $this->meta_value
+                : $value;
+
+            # catch an error
         } catch (Exception $ex) {
             return $this->meta_value;
         }

--- a/src/Eloquent/Model/Option.php
+++ b/src/Eloquent/Model/Option.php
@@ -49,7 +49,7 @@ class Option extends Model
     public function getValueAttribute()
     {
         try {
-            $value = unserialize($this->option_value);
+            $value = @unserialize($this->option_value);
 
             return $value === false && $this->option_value !== false ?
                 $this->option_value :

--- a/src/Eloquent/Model/Option.php
+++ b/src/Eloquent/Model/Option.php
@@ -49,11 +49,13 @@ class Option extends Model
     public function getValueAttribute()
     {
         try {
-            $value = @unserialize($this->option_value);
+            $value = @unserialize($this->option_value); # prevent notice sent when not serialized string
 
-            return $value === false && $this->option_value !== false ?
-                $this->option_value :
-                $value;
+            return $value === false && $this->option_value !== false && $this->meta_value !== 'b:0;'
+                ? $this->option_value
+                : $value;
+
+            # catch an error
         } catch (Exception $ex) {
             return $this->option_value;
         }


### PR DESCRIPTION
Fix a notice thrown on the usage of `unserialize()` on a not serialized string (meta, options)