### PR TITLE
:bug: Fix ids() PostBuilder scope

### DIFF
--- a/src/Eloquent/Model/Builder/PostBuilder.php
+++ b/src/Eloquent/Model/Builder/PostBuilder.php
@@ -139,4 +139,27 @@ class PostBuilder extends Builder
                 ->orderByRaw('LENGTH(meta_ordering)', 'ASC') # alphanum support, avoid this kind of sort : 1, 10, 11, 7, 8
                 ->orderBy('meta_ordering', $order);
     }
+
+    /**
+     * Filter the query to include the given post ids, in the given order.
+     * 
+     * @param array   $ids
+     */
+    public function whereIds(array $ids)
+    {
+        return empty($ids)
+                ? $this
+                : $this->whereIn('ID', $ids)
+                    ->orderByRaw(sprintf('FIELD(ID, %s)', implode(',', $ids)));
+    }
+    
+    /**
+     * Filter the query to include the given post ids, in the given order.
+     * 
+     * @deprecated Use whereIds() instead.
+     */
+    public function ids(array $ids)
+    {
+        return $this->whereIds($ids);
+    }
 }

--- a/src/Eloquent/Model/Post.php
+++ b/src/Eloquent/Model/Post.php
@@ -431,31 +431,7 @@ class Post extends Model implements WpEloquentPost
 
 
     /******************************************/
-    /*                                        */
-    /*            Eloquent scopes             */
-    /*                                        */
-    /******************************************/
-
-
-    /**
-     * Get a collection of posts from their ids, keeping the given ids ordering.
-     *
-     * Eg: Post::ids([10,12,11])->get()
-     *
-     * @param Builder $query
-     * @param array   $ids
-     */
-    public function scopeIds(Builder $query, array $ids)
-    {
-        return $query->whereIn('ID', $ids)
-                    ->orderByRaw(sprintf('FIELD(ID, %s)', implode(',', $ids)));
-    }
-
-
-    /******************************************/
-    /*                                        */
     /*             Post attributes            */
-    /*                                        */
     /******************************************/
 
 
@@ -492,11 +468,6 @@ class Post extends Model implements WpEloquentPost
         return (int) ($meta = $this->getThumbnailMeta())
                         ? $meta->meta_value
                         : 0;
-        
-        // if (!$this->thumbnail_meta) {
-        //     return 0;
-        // }
-        // return ((int) $this->thumbnail_meta->meta_value) ?: 0;
     }
     
     /**
@@ -514,9 +485,7 @@ class Post extends Model implements WpEloquentPost
 
 
     /******************************************/
-    /*                                        */
     /*        WordPress methods aliases       */
-    /*                                        */
     /******************************************/
 
 


### PR DESCRIPTION
Fix an issue where passing an empty array of ids to ids() scope were breaking the builder. Also, renamed to whereIds() and moved scope to Builder class.