### PR TITLE
:bug: Fix the whereIds() condition so it actually filters when the id…

### DIFF
--- a/src/Eloquent/Model/Builder/PostBuilder.php
+++ b/src/Eloquent/Model/Builder/PostBuilder.php
@@ -148,7 +148,7 @@ class PostBuilder extends Builder
     public function whereIds(array $ids)
     {
         return empty($ids)
-                ? $this
+                ? $this->whereIn('ID', [])
                 : $this->whereIn('ID', $ids)
                     ->orderByRaw(sprintf('FIELD(ID, %s)', implode(',', $ids)));
     }


### PR DESCRIPTION
…s array is empty instead of skipping